### PR TITLE
Type generic observer method

### DIFF
--- a/hood.cabal
+++ b/hood.cabal
@@ -1,5 +1,5 @@
 Name:                hood
-Version:             0.2.1
+Version:             0.2.2
 Synopsis:            Debugging by observing in place
 Description:         Hood debugger, based on the idea of observing functions and structures as they are evaluated.
 Category:            Debug, Trace
@@ -7,7 +7,7 @@ License:             BSD3
 License-file:        LICENSE
 Author:              Andy Gill
 Maintainer:          Andy Gill <andygill@ku.edu>
-Copyright:           (c) 2000 Andy Gill, (c) 2010-2015 University of Kansas
+Copyright:           (c) 2000 Andy Gill, (c) 2010-2015 University of Kansas, (c) 2013-2015 Maarten Faddegon
 Homepage:            http://www.ittc.ku.edu/csdl/fpg/Hood
 bug-reports:         https://github.com/ku-fpg/hood/issues
 Stability:           alpha

--- a/hood.cabal
+++ b/hood.cabal
@@ -1,5 +1,5 @@
 Name:                hood
-Version:             0.2.2
+Version:             0.2.3
 Synopsis:            Debugging by observing in place
 Description:         Hood debugger, based on the idea of observing functions and structures as they are evaluated.
 Category:            Debug, Trace
@@ -12,11 +12,11 @@ Homepage:            http://www.ittc.ku.edu/csdl/fpg/Hood
 bug-reports:         https://github.com/ku-fpg/hood/issues
 Stability:           alpha
 build-type:          Simple
-Cabal-Version:       >= 1.6
+Cabal-Version:       >= 1.8
 extra-source-files:  CHANGELOG.md, README.md
 
 Library
-  Build-Depends: base >= 4 && < 5, array
+  Build-Depends: base >= 4 && < 5, array, FPretty
   Exposed-modules:
       Debug.Hood.Observe
 


### PR DESCRIPTION
Hi Andy,

This is the implementation of the type generic observer method we discussed at PLDI. I copied the implementation from the Hoed library.

We can make type MyType Observable as follows:

```
data MyType = MyConstr Int String deriving Generic
instance Observable MyType
```

After which values of MyType can be observed as usual.

Best,
Maarten
