### PR TITLE
Why not export CDSSet?

### DIFF
--- a/Debug/Hood/Observe.hs
+++ b/Debug/Hood/Observe.hs
@@ -61,6 +61,7 @@ module Debug.Hood.Observe
 
   , debugO         -- IO a -> IO [CDS]
   , CDS(..)
+  , CDSSet
   ) where
 
 {-


### PR DESCRIPTION
Makes it easier to understand the structure of CDS.

Thanks for the interesting package.
I'm a little interested in making a new renderer.
But I got confused a little after reading the [document](http://hackage.haskell.org/package/hood-0.3/docs/Debug-Hood-Observe.html) due to the absence of the definition of CDSSet.