### PR TITLE
Don't increment node id when the function passed to unsafeWithUniq throws an Exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cabal.sandbox.config
 *.aux
 *.hp
 *~
+
+.stack-work/

--- a/Debug/Hood/Observe.hs
+++ b/Debug/Hood/Observe.hs
@@ -596,6 +596,7 @@ sendEvent nodeId parent change =
            }
 
 -- local
+{-# NOINLINE events #-}
 events :: IORef [Event]
 events = unsafePerformIO $ newIORef badEvents
 

--- a/Debug/Hood/Observe.hs
+++ b/Debug/Hood/Observe.hs
@@ -511,8 +511,10 @@ root = Parent 0 0
 
 unsafeWithUniq :: (Int -> IO a) -> a
 unsafeWithUniq fn
-  = unsafePerformIO $ do { node <- getUniq
-                         ; fn node
+  = unsafePerformIO $ do { node <- readUniq
+                         ; r <- fn node
+                         ; incrementUniq node
+                         ; return r
                          }
 
 generateContext :: (Observable a) => String -> a -> a
@@ -622,17 +624,11 @@ Use the single threaded version
 initUniq :: IO ()
 initUniq = writeIORef uniq 1
 
-getUniq :: IO Int
-getUniq
-    = do { takeMVar uniqSem
-         ; n <- readIORef uniq
-         ; writeIORef uniq $! (n + 1)
-         ; putMVar uniqSem ()
-         ; return n
-         }
+incrementUniq :: Int -> IO ()
+incrementUniq n = writeIORef uniq $! (n + 1)
 
-peepUniq :: IO Int
-peepUniq = readIORef uniq
+readUniq :: IO Int
+readUniq = readIORef uniq
 
 -- locals
 {-# NOINLINE uniq #-}

--- a/Debug/Hood/Observe.hs
+++ b/Debug/Hood/Observe.hs
@@ -309,7 +309,7 @@ class Observable a where
          - This used used to group several observer instances together.
          -}
         observers :: String -> (Observer -> a) -> a
-        observers label arg = defaultObservers label arg
+        observers = defaultObservers
 
 class GObservable f where
         gdmobserver :: f a -> Parent -> f a
@@ -376,7 +376,7 @@ gthunk a = ObserverM $ \ parent port ->
                 , port+1 )
 
 gdmobserver_ :: (GObservable f) => f a -> Parent -> f a
-gdmobserver_ a context = gsendEnterPacket a context
+gdmobserver_ = gsendEnterPacket
 
 gsendEnterPacket :: (GObservable f) => f a -> Parent -> f a
 gsendEnterPacket r context = unsafeWithUniq $ \ node ->
@@ -489,7 +489,7 @@ Our principal function and class
 --
 {-# NOINLINE observe #-}
 observe :: (Observable a) => String -> a -> a
-observe name a = generateContext name a
+observe = generateContext
 
 {- This gets called before observer, allowing us to mark
  - we are entering a, before we do case analysis on
@@ -498,7 +498,7 @@ observe name a = generateContext name a
 
 {-# NOINLINE observer_ #-}
 observer_ :: (Observable a) => a -> Parent -> a
-observer_ a context = sendEnterPacket a context
+observer_ = sendEnterPacket
 
 data Parent = Parent
         { observeParent :: !Int -- my parent
@@ -683,7 +683,7 @@ type CDSSet = [CDS]
 eventsToCDS :: [Event] -> CDSSet
 eventsToCDS pairs = getChild 0 0
    where
-     res i = (!) out_arr i
+     res = (!) out_arr
 
      bnds = (0, length pairs)
 

--- a/Debug/Hood/Observe.hs
+++ b/Debug/Hood/Observe.hs
@@ -163,7 +163,7 @@ runO program =
        ; let cdss2 = simplifyCDSSet cdss1
        ; let output1 = cdssToOutput cdss2
        ; let output2 = commonOutput output1
-       ; let ptyout  = pretty 80 (foldr (<>) nil (map renderTop output2))
+       ; let ptyout  = pretty 80 $ foldr ((<>) . renderTop) nil output2
        ; hPutStrLn stderr ""
        ; hPutStrLn stderr ptyout
        }

--- a/Debug/Hood/Observe.hs
+++ b/Debug/Hood/Observe.hs
@@ -781,7 +781,7 @@ findFn' (CDSFun _ arg res) rest =
 findFn' other rest = ([],[other]) : rest
 
 renderTops []   = nil
-renderTops tops = line <> foldr (<>) nil (map renderTop tops)
+renderTops tops = line <> foldr ((<>) . renderTop ) nil tops
 
 renderTop :: Output -> Doc
 renderTop (OutLabel str set extras) =

--- a/hood.cabal
+++ b/hood.cabal
@@ -25,6 +25,12 @@ Library
   Exposed-modules:
       Debug.Hood.Observe
 
+Test-Suite hood-test
+  Type:                exitcode-stdio-1.0
+  Hs-Source-Dirs:      test
+  Main-Is:             test.hs
+  Build-Depends:       base, hood
+
 source-repository head
     type:     git
     location: https://github.com/ku-fpg/hood

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,0 +1,26 @@
+#!/usr/bin/env stack
+{-# LANGUAGE DeriveGeneric #-}
+-- stack --resolver lts-8.4 runghc --package hood
+-- Minimum program to reproduce https://github.com/ku-fpg/hood/issues/5
+
+import           Debug.Hood.Observe
+import           GHC.Generics
+
+
+data Hoge =
+  Hoge
+    { hoge1 :: Int
+    , hoge2 :: String
+    } deriving Generic
+
+instance Observable Hoge
+
+
+main :: IO ()
+main = runO $ print $ f undefined
+
+
+f :: Hoge -> Bool
+f = observe "f" f'
+f' :: Hoge -> Bool
+f' h@(Hoge _h1 _h2) = error "ERROR"


### PR DESCRIPTION
Fix #5 by incrementing the node id **only when the function is executed without exception**

Notes on Thread-Safety
====

This change would make hood less thread-safe because it doesn't lock `uniqSem` when reading anymore.
But IMO hood needs much more changes to be truly thread-safe
(for example, save the event stream and node id counter in thread-local variable)
So I think lowering the thread-safety by this change isn't be a big problem.

Notes on the Other Commits
====

I also added some non-related commits to refactor hood.
Most of them are to fix warnings by hlint.
Feel free to tell me to revert them if you don't like.